### PR TITLE
feat(greeting): add wave emoji and shake animation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -120,3 +120,18 @@ button:disabled {
   border-color: #ffa8a8;
   color: #7d1a1a;
 }
+
+@keyframes shake {
+  0%   { transform: translateX(0); }
+  15%  { transform: translateX(-8px) rotate(-2deg); }
+  30%  { transform: translateX(8px) rotate(2deg); }
+  45%  { transform: translateX(-6px) rotate(-1deg); }
+  60%  { transform: translateX(6px) rotate(1deg); }
+  75%  { transform: translateX(-3px); }
+  90%  { transform: translateX(3px); }
+  100% { transform: translateX(0); }
+}
+
+.shake {
+  animation: shake 0.6s ease-in-out;
+}

--- a/frontend/src/components/GreetingForm.test.tsx
+++ b/frontend/src/components/GreetingForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GreetingForm } from './GreetingForm'
@@ -60,7 +60,7 @@ describe('GreetingForm', () => {
   it('should show the greeting message when a name is submitted', async () => {
     // ARRANGE
     const user = userEvent.setup()
-    vi.stubGlobal('fetch', mockFetchOk({ message: 'Hello, Daniel!' }))
+    vi.stubGlobal('fetch', mockFetchOk({ message: 'Hello, Daniel! 👋' }))
     render(<GreetingForm />)
 
     // ACT
@@ -69,7 +69,7 @@ describe('GreetingForm', () => {
 
     // ASSERT
     const result = await screen.findByRole('status')
-    expect(result).toHaveTextContent('Hello, Daniel!')
+    expect(result).toHaveTextContent('Hello, Daniel! 👋')
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
@@ -156,5 +156,52 @@ describe('GreetingForm', () => {
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent('Network error')
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // 7. Applies shake class after a successful greeting
+  // -------------------------------------------------------------------------
+  it('should apply the shake class to the greeting-form div after a successful greeting', async () => {
+    // ARRANGE
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', mockFetchOk({ message: 'Hello, Daniel! 👋' }))
+    render(<GreetingForm />)
+
+    // ACT
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Daniel')
+    await user.click(screen.getByRole('button', { name: /greet/i }))
+
+    // ASSERT — shake class is added once the greeting arrives
+    const form = await screen.findByRole('status')
+    const container = form.closest('.greeting-form')
+    await waitFor(() => {
+      expect(container).toHaveClass('shake')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 8. Removes shake class after onAnimationEnd fires
+  // -------------------------------------------------------------------------
+  it('should remove the shake class after the animation ends', async () => {
+    // ARRANGE
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', mockFetchOk({ message: 'Hello, Daniel! 👋' }))
+    const { container } = render(<GreetingForm />)
+
+    // ACT
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Daniel')
+    await user.click(screen.getByRole('button', { name: /greet/i }))
+
+    // Wait for the shake class to appear first
+    const greetingDiv = container.querySelector('.greeting-form')!
+    await waitFor(() => expect(greetingDiv).toHaveClass('shake'))
+
+    // Simulate the animation ending
+    await act(async () => {
+      fireEvent.animationEnd(greetingDiv, { bubbles: true })
+    })
+
+    // ASSERT — shake class is removed after the animation ends
+    await waitFor(() => expect(greetingDiv).not.toHaveClass('shake'))
   })
 })

--- a/frontend/src/components/GreetingForm.tsx
+++ b/frontend/src/components/GreetingForm.tsx
@@ -9,6 +9,7 @@ export function GreetingForm() {
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [shaking, setShaking] = useState(false)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -27,6 +28,7 @@ export function GreetingForm() {
 
       const data: GreetingResponse = await res.json()
       setMessage(data.message)
+      setShaking(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unexpected error')
     } finally {
@@ -35,7 +37,7 @@ export function GreetingForm() {
   }
 
   return (
-    <div className="greeting-form">
+    <div className={`greeting-form${shaking ? ' shake' : ''}`} onAnimationEnd={() => setShaking(false)}>
       <h1>Greeting Service</h1>
       <form onSubmit={handleSubmit}>
         <div className="input-row">

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom'
+
+// Polyfill AnimationEvent for jsdom, which doesn't implement CSS animation APIs.
+// Without this, React's vendor-prefix detection maps `onAnimationEnd` to
+// `webkitAnimationEnd`, making it impossible to trigger via standard test helpers.
+if (!('AnimationEvent' in window)) {
+  ;(window as any).AnimationEvent = Event
+}

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/application/GreetingService.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/application/GreetingService.java
@@ -19,7 +19,7 @@ public class GreetingService implements GreetUseCase {
         log.trace("greet() called with name='{}'", name);
         String normalized = (name == null || name.isBlank()) ? "World" : name.trim();
         log.debug("Normalized name: '{}'", normalized);
-        Greeting greeting = new Greeting(normalized, "Hello, " + normalized + "!");
+        Greeting greeting = new Greeting(normalized, "Hello, " + normalized + "! 👋");
         log.info("Greeting created for '{}'", normalized);
         saveGreetingPort.save(greeting);
         log.debug("Greeting persisted for '{}'", normalized);

--- a/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingControllerTest.java
+++ b/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingControllerTest.java
@@ -23,11 +23,11 @@ class GreetingControllerTest {
 
     @Test
     void returnsGreetingPayload() throws Exception {
-        given(greetUseCase.greet("Daniel")).willReturn(new Greeting("Daniel", "Hello, Daniel!"));
+        given(greetUseCase.greet("Daniel")).willReturn(new Greeting("Daniel", "Hello, Daniel! 👋"));
 
         mockMvc.perform(get("/api/greeting").param("name", "Daniel"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json"))
-                .andExpect(jsonPath("$.message").value("Hello, Daniel!"));
+                .andExpect(jsonPath("$.message").value("Hello, Daniel! 👋"));
     }
 }

--- a/src/test/resources/features/greeting.feature
+++ b/src/test/resources/features/greeting.feature
@@ -3,9 +3,9 @@ Feature: Greeting endpoint
   Scenario: Greeting a named user
     When the client requests greeting for "Daniel"
     Then the response status is 200
-    And the greeting message is "Hello, Daniel!"
+    And the greeting message is "Hello, Daniel! 👋"
 
   Scenario: Greeting falls back to the default user
     When the client requests the default greeting
     Then the response status is 200
-    And the greeting message is "Hello, World!"
+    And the greeting message is "Hello, World! 👋"


### PR DESCRIPTION
## Summary

Implements #11 — adds a wave emoji 👋 to the greeting and a shake animation in the UI.

### Changes
- **Backend**: `GreetingService` now returns `"Hello, <name>! 👋"`
- **Frontend**: `GreetingForm` applies a CSS shake animation to the whole card when a greeting is received; resets automatically via `onAnimationEnd` for retriggering
- **CSS**: `@keyframes shake` (translateX + rotate, 0.6 s) added to `App.css`
- **Tests**: `GreetingControllerTest`, `greeting.feature`, and `GreetingForm.test.tsx` updated and extended with animation tests

Closes #11

Closes #11