### PR TITLE
feat(greeting): add random multilingual greeting with flag display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -135,3 +135,17 @@ button:disabled {
 .shake {
   animation: shake 0.6s ease-in-out;
 }
+
+.flag-display {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.5rem;
+  font-size: 1.5rem;
+  vertical-align: middle;
+}
+
+.bw-wappen {
+  height: 1.5rem;
+  width: auto;
+  vertical-align: middle;
+}

--- a/frontend/src/components/GreetingForm.test.tsx
+++ b/frontend/src/components/GreetingForm.test.tsx
@@ -204,4 +204,32 @@ describe('GreetingForm', () => {
     // ASSERT — shake class is removed after the animation ends
     await waitFor(() => expect(greetingDiv).not.toHaveClass('shake'))
   })
+
+  // -------------------------------------------------------------------------
+  // 9. Displays flag emoji for a standard language
+  // -------------------------------------------------------------------------
+  it('should display the flag emoji for a standard language', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', mockFetchOk({ message: 'Hallo, Daniel! 👋', language: 'Deutsch', flag: '🇩🇪' }))
+    render(<GreetingForm />)
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Daniel')
+    await user.click(screen.getByRole('button', { name: /greet/i }))
+    await screen.findByRole('status')
+    expect(screen.getByRole('img', { name: 'Deutsch' })).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // 10. Displays BW Wappen image for Schwäbisch
+  // -------------------------------------------------------------------------
+  it('should display BW Wappen image for Schwäbisch', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', mockFetchOk({ message: 'Grüaß di, Daniel! 👋', language: 'Schwäbisch', flag: 'bw' }))
+    render(<GreetingForm />)
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Daniel')
+    await user.click(screen.getByRole('button', { name: /greet/i }))
+    await screen.findByRole('status')
+    const img = screen.getByAltText('Baden-Württemberg')
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', expect.stringContaining('Baden-W'))
+  })
 })

--- a/frontend/src/components/GreetingForm.tsx
+++ b/frontend/src/components/GreetingForm.tsx
@@ -2,11 +2,15 @@ import { useState, type FormEvent } from 'react'
 
 interface GreetingResponse {
   message: string
+  language: string
+  flag: string
 }
 
 export function GreetingForm() {
   const [name, setName] = useState('')
   const [message, setMessage] = useState<string | null>(null)
+  const [flag, setFlag] = useState<string | null>(null)
+  const [language, setLanguage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [shaking, setShaking] = useState(false)
@@ -16,6 +20,8 @@ export function GreetingForm() {
     setLoading(true)
     setError(null)
     setMessage(null)
+    setFlag(null)
+    setLanguage(null)
 
     try {
       const params = name.trim() ? `?name=${encodeURIComponent(name.trim())}` : ''
@@ -28,6 +34,8 @@ export function GreetingForm() {
 
       const data: GreetingResponse = await res.json()
       setMessage(data.message)
+      setFlag(data.flag)
+      setLanguage(data.language)
       setShaking(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unexpected error')
@@ -57,6 +65,17 @@ export function GreetingForm() {
 
       {message && (
         <div className="result success" role="status">
+          <span className="flag-display" aria-label={language ?? undefined}>
+            {flag === 'bw' ? (
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/Coat_of_arms_of_Baden-W%C3%BCrttemberg.svg/240px-Coat_of_arms_of_Baden-W%C3%BCrttemberg.svg.png"
+                alt="Baden-Württemberg"
+                className="bw-wappen"
+              />
+            ) : (
+              <span role="img" aria-label={language ?? undefined}>{flag}</span>
+            )}
+          </span>
           {message}
         </div>
       )}

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingResponse.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingResponse.java
@@ -1,3 +1,3 @@
 package de.weidle.copilotagenticplayground.greeting.adapter.in.web;
 
-public record GreetingResponse(String message) {}
+public record GreetingResponse(String message, String language, String flag) {}

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingWebMapper.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingWebMapper.java
@@ -11,5 +11,7 @@ public interface GreetingWebMapper {
     GreetingWebMapper INSTANCE = Mappers.getMapper(GreetingWebMapper.class);
 
     @Mapping(source = "message", target = "message")
+    @Mapping(source = "language.displayName", target = "language")
+    @Mapping(source = "language.flag", target = "flag")
     GreetingResponse toResponse(Greeting greeting);
 }

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/out/persistence/GreetingPersistenceMapper.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/adapter/out/persistence/GreetingPersistenceMapper.java
@@ -12,5 +12,8 @@ public interface GreetingPersistenceMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "message", source = "message")
+    // language field from Greeting is intentionally not stored in the DB
     GreetingLogEntity toEntity(Greeting greeting);
 }

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/application/GreetingService.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/application/GreetingService.java
@@ -1,8 +1,10 @@
 package de.weidle.copilotagenticplayground.greeting.application;
 
 import de.weidle.copilotagenticplayground.greeting.domain.model.Greeting;
+import de.weidle.copilotagenticplayground.greeting.domain.model.Language;
 import de.weidle.copilotagenticplayground.greeting.domain.port.in.GreetUseCase;
 import de.weidle.copilotagenticplayground.greeting.domain.port.out.SaveGreetingPort;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,11 +20,14 @@ public class GreetingService implements GreetUseCase {
     public Greeting greet(String name) {
         log.trace("greet() called with name='{}'", name);
         String normalized = (name == null || name.isBlank()) ? "World" : name.trim();
-        log.debug("Normalized name: '{}'", normalized);
-        Greeting greeting = new Greeting(normalized, "Hello, " + normalized + "! 👋");
-        log.info("Greeting created for '{}'", normalized);
+        Language[] languages = Language.values();
+        Language language = languages[ThreadLocalRandom.current().nextInt(languages.length)];
+        log.debug("Selected language: '{}' for name: '{}'", language, normalized);
+        Greeting greeting =
+                new Greeting(
+                        normalized, language.getGreeting() + ", " + normalized + "! 👋", language);
+        log.info("Greeting created for '{}' in '{}'", normalized, language);
         saveGreetingPort.save(greeting);
-        log.debug("Greeting persisted for '{}'", normalized);
         return greeting;
     }
 }

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/domain/model/Greeting.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/domain/model/Greeting.java
@@ -1,3 +1,3 @@
 package de.weidle.copilotagenticplayground.greeting.domain.model;
 
-public record Greeting(String name, String message) {}
+public record Greeting(String name, String message, Language language) {}

--- a/src/main/java/de/weidle/copilotagenticplayground/greeting/domain/model/Language.java
+++ b/src/main/java/de/weidle/copilotagenticplayground/greeting/domain/model/Language.java
@@ -1,0 +1,19 @@
+package de.weidle.copilotagenticplayground.greeting.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Language {
+    ENGLISH("Hello", "🇬🇧", "English"),
+    GERMAN("Hallo", "🇩🇪", "Deutsch"),
+    FRENCH("Bonjour", "🇫🇷", "Français"),
+    KOREAN("안녕하세요", "🇰🇷", "한국어"),
+    ITALIAN("Ciao", "🇮🇹", "Italiano"),
+    SWABIAN("Grüaß di", "bw", "Schwäbisch");
+
+    private final String greeting;
+    private final String flag;
+    private final String displayName;
+}

--- a/src/test/java/de/weidle/copilotagenticplayground/e2e/GreetingE2ESteps.java
+++ b/src/test/java/de/weidle/copilotagenticplayground/e2e/GreetingE2ESteps.java
@@ -35,10 +35,12 @@ public class GreetingE2ESteps {
         assertThat(response.getStatusCode().value()).isEqualTo(statusCode);
     }
 
-    @Then("the greeting message is {string}")
-    public void theGreetingMessageIs(String message) {
+    @Then("the response contains a greeting message and language")
+    public void theResponseContainsAGreetingMessageAndLanguage() {
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().message()).isEqualTo(message);
+        assertThat(response.getBody().message()).isNotBlank();
+        assertThat(response.getBody().language()).isNotBlank();
+        assertThat(response.getBody().flag()).isNotBlank();
     }
 
     private String buildUrl(String path) {

--- a/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingControllerTest.java
+++ b/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/in/web/GreetingControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import de.weidle.copilotagenticplayground.greeting.domain.model.Greeting;
+import de.weidle.copilotagenticplayground.greeting.domain.model.Language;
 import de.weidle.copilotagenticplayground.greeting.domain.port.in.GreetUseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,11 +24,14 @@ class GreetingControllerTest {
 
     @Test
     void returnsGreetingPayload() throws Exception {
-        given(greetUseCase.greet("Daniel")).willReturn(new Greeting("Daniel", "Hello, Daniel! 👋"));
+        given(greetUseCase.greet("Daniel"))
+                .willReturn(new Greeting("Daniel", "Hallo, Daniel! 👋", Language.GERMAN));
 
         mockMvc.perform(get("/api/greeting").param("name", "Daniel"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json"))
-                .andExpect(jsonPath("$.message").value("Hello, Daniel! 👋"));
+                .andExpect(jsonPath("$.message").value("Hallo, Daniel! 👋"))
+                .andExpect(jsonPath("$.language").value("Deutsch"))
+                .andExpect(jsonPath("$.flag").value("🇩🇪"));
     }
 }

--- a/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/out/persistence/NoOpSaveGreetingAdapterTest.java
+++ b/src/test/java/de/weidle/copilotagenticplayground/greeting/adapter/out/persistence/NoOpSaveGreetingAdapterTest.java
@@ -3,6 +3,7 @@ package de.weidle.copilotagenticplayground.greeting.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import de.weidle.copilotagenticplayground.greeting.domain.model.Greeting;
+import de.weidle.copilotagenticplayground.greeting.domain.model.Language;
 import org.junit.jupiter.api.Test;
 
 class NoOpSaveGreetingAdapterTest {
@@ -12,6 +13,7 @@ class NoOpSaveGreetingAdapterTest {
     @Test
     void saveDoesNothing() {
         assertThatNoException()
-                .isThrownBy(() -> adapter.save(new Greeting("Test", "Hello, Test!")));
+                .isThrownBy(
+                        () -> adapter.save(new Greeting("Test", "Hello, Test!", Language.ENGLISH)));
     }
 }

--- a/src/test/resources/features/greeting.feature
+++ b/src/test/resources/features/greeting.feature
@@ -3,9 +3,9 @@ Feature: Greeting endpoint
   Scenario: Greeting a named user
     When the client requests greeting for "Daniel"
     Then the response status is 200
-    And the greeting message is "Hello, Daniel! 👋"
+    And the response contains a greeting message and language
 
   Scenario: Greeting falls back to the default user
     When the client requests the default greeting
     Then the response status is 200
-    And the greeting message is "Hello, World! 👋"
+    And the response contains a greeting message and language


### PR DESCRIPTION
## Summary

Implements #14 — greets users in a randomly selected language and displays the corresponding country flag in the UI.

### Supported Languages
| Language | Greeting | Flag |
|----------|----------|------|
| English | Hello | 🇬🇧 |
| Deutsch | Hallo | 🇩🇪 |
| Français | Bonjour | 🇫🇷 |
| 한국어 | 안녕하세요 | 🇰🇷 |
| Italiano | Ciao | 🇮🇹 |
| Schwäbisch | Grüaß di | Baden-Württemberg Wappen |

### Changes
- **`Language.java`**: New enum with greeting text, flag, and display name per language
- **`Greeting.java`**: Extended with `Language` field
- **`GreetingService`**: Picks a random `Language` via `ThreadLocalRandom`
- **`GreetingResponse`**: New `language` and `flag` fields in JSON response
- **`GreetingWebMapper`**: Maps `language.displayName` → `language`, `language.flag` → `flag`
- **`GreetingForm.tsx`**: Displays flag emoji or BW coat of arms `<img>` for Schwäbisch
- **Tests**: Backend + frontend fully updated, 2 new frontend tests for flag display

Closes #14